### PR TITLE
Update data_protection.md

### DIFF
--- a/data_protection.md
+++ b/data_protection.md
@@ -6,12 +6,12 @@ Global Code takes volunteers to West Africa for three weeks every July, to teach
 
 We are a charity registered in the UK, number 1176504
 
-In order to run the Summer Program we need to collect some personal information about you. The information is currently only available to Global Code staff, and will only ever be available to the Global Code staff and relevant agents. For example, we may need to pass along your passport details to a travel agent.
+In order to run the Summer Program we need to collect some personal information about you. The information is currently only available to Global Code staff, and will only ever be available to the Global Code staff and relevant agents. For example, we may need to pass along your passport details to the universities for a visa support letter.
 
 We collect your name, address, passport number, telephone number, and email address for planning purposes. We’ll keep this on file for three years unless you ask us to delete it sooner, in which case we will. Currently it’s stored in a document in Google Drive, and we have no control over Google’s retention policies. 
 
-We’ll be taking photographs before, during, and after the program. We’ll make the photos available to media agencies and put them on our website and on twitter. If you ask, we’ll take them down.
+We’ll be taking photographs before, during, and after the program. We’ll make the photos available to media agencies and put them on our website, LinkedIn, Instagram and on twitter. If you ask, we’ll take them down.
 
 Ghana and Nigeria both require foreign nationals to have been vaccinated against Yellow Fever at least ten days before the date of travel, and so we’ll also need to know the details of your Yellow Fever vaccination.
 
-We care deeply about your privacy and won’t pass on the information you give me to any third parties unless it’s necessary for the program to run, and we’ll let you know if that’s the case. 
+We care deeply about your privacy and won’t pass on the information you give us to any third parties unless it’s necessary for the program to run, and we’ll let you know if that’s the case. 


### PR DESCRIPTION
Made a few minor changes: uses the example of a visa support letter for passing on personal information to 3rd parties; added LinkedIn and Instagram to use of photographs.